### PR TITLE
feat(Openstack): printout compose_id when using -latest image pointer

### DIFF
--- a/src/mrack/host.py
+++ b/src/mrack/host.py
@@ -51,6 +51,7 @@ def host_from_json(host_data):
         host_data["username"],
         host_data["password"],
         host_data["error"],
+        host_data["meta_extra"],
     )
     return host
 
@@ -74,6 +75,7 @@ class Host:
         username=None,
         password=None,
         error_obj=None,
+        meta_extra=None,
     ):
         """Initialize host object."""
         self._provider = provider
@@ -87,6 +89,7 @@ class Host:
         self._password = password
         self._rawdata = rawdata
         self._error = error_obj
+        self._meta_extra = meta_extra
 
     def __str__(self):
         """Return string representation of host."""
@@ -120,6 +123,7 @@ class Host:
             "password": self._password,
             "rawdata": self._rawdata,
             "error": self._error,
+            "meta_extra": self._meta_extra,
         }
 
     @property
@@ -181,6 +185,11 @@ class Host:
     def password(self):
         """Get password for connecting to host."""
         return self._password
+
+    @property
+    def meta_extra(self):
+        """Get host extra meta information."""
+        return self._meta_extra
 
     async def delete(self):
         """Issue host deletion via associated provider."""

--- a/src/mrack/outputs/ansible_inventory.py
+++ b/src/mrack/outputs/ansible_inventory.py
@@ -167,6 +167,10 @@ class AnsibleInventoryOutput:
         if db_host.provider.name in ("docker", "podman"):
             host_info.update({"ansible_user": "root"})  # TODO make it configurable
 
+        if db_host.meta_extra:
+            for key, value in db_host.meta_extra.items():
+                host_info.update({key: value})
+
         if is_windows_host(meta_host):
             if "netbios" in meta_host:
                 host_info.update({"meta_netbios": meta_host["netbios"]})

--- a/src/mrack/providers/openstack.py
+++ b/src/mrack/providers/openstack.py
@@ -582,6 +582,13 @@ class OpenStackProvider(Provider):
             del specs["flavor"]
 
         image = self._translate_image(req)
+        if image["meta_compose_id"] and image["meta_compose_url"]:
+            logger.info(
+                f"{self.dsp_name}: Image meta_compose_id: {image['meta_compose_id']}"
+                f"\n{self.dsp_name}: Image meta_compose_url:"
+                f" {image['meta_compose_url']}"
+            )
+
         specs["imageRef"] = image["id"]
         if specs.get("image"):
             del specs["image"]
@@ -738,6 +745,13 @@ class OpenStackProvider(Provider):
     def prov_result_to_host_data(self, prov_result, req):
         """Get needed host information from openstack provisioning result."""
         result = {}
+        meta_extra = {}
+        image = self._translate_image(req)
+        # Check if these fields exists, not all images have them
+        if image.get("meta_compose_id"):
+            meta_extra["meta_compose_id"] = image.get("meta_compose_id")
+        if image.get("meta_compose_url"):
+            meta_extra["meta_compose_url"] = image.get("meta_compose_url")
 
         result["id"] = prov_result.get("id")
         result["name"] = req.get("name")
@@ -747,5 +761,6 @@ class OpenStackProvider(Provider):
         result["status"] = prov_result.get("status")
         result["os"] = prov_result.get("mrack_req").get("os")
         result["group"] = prov_result.get("mrack_req").get("group")
+        result["meta_extra"] = meta_extra
 
         return result

--- a/src/mrack/providers/provider.py
+++ b/src/mrack/providers/provider.py
@@ -490,5 +490,6 @@ class Provider:
             username=username,
             password=host_info.get("password"),
             error_obj=host_info.get("fault"),
+            meta_extra=host_info.get("meta_extra"),
         )
         return host

--- a/tests/unit/mock_data.py
+++ b/tests/unit/mock_data.py
@@ -88,6 +88,7 @@ def create_db_host(
     username=None,
     password=None,
     provider="openstack",
+    meta_extra=None,
 ):
     """Create Host object based on minimal info."""
 
@@ -100,31 +101,32 @@ def create_db_host(
         [get_ip(index)],
         status,
         {},
+        meta_extra=meta_extra,
         username=username,
         password=password,
         error_obj=None,
     )
 
 
-def create_db(hostnames, provider="openstack"):
+def create_db(hostnames, provider="openstack", meta_extra=None):
     """Create artificial DB based on hostnames."""
     db = FileDBDriver("mock_path")
     db.save_on_change = False  # to prevent attempt to save when adding hosts
 
     for index, hostname in enumerate(hostnames):
-        host = create_db_host(hostname, index, provider=provider)
+        host = create_db_host(hostname, index, provider=provider, meta_extra=meta_extra)
         db.add_hosts([host])
     return db
 
 
-def get_db_from_metadata(metadata, provider="openstack"):
+def get_db_from_metadata(metadata, provider="openstack", host_extra=None):
     """Create DB from metadata for testing."""
     hostnames = []
     for domain in metadata.get("domains", []):
         for host in domain.get("hosts", []):
             hostnames.append(host["name"])
 
-    db = create_db(hostnames)
+    db = create_db(hostnames, meta_extra=host_extra)
     return db
 
 

--- a/tests/unit/test_ansible_inventory.py
+++ b/tests/unit/test_ansible_inventory.py
@@ -67,6 +67,17 @@ def db(metadata):
     return get_db_from_metadata(metadata)
 
 
+@pytest.fixture()
+def db_meta_extra(metadata):
+    return get_db_from_metadata(
+        metadata,
+        host_extra={  # Sample data
+            "meta_compose_id": "ID.0-20220317.0",
+            "meta_compose_url": "http://dummy.com/compose/compose_id",
+        },
+    )
+
+
 def empty_layout():
     return {
         "all": {},
@@ -118,3 +129,64 @@ class TestAnsibleInventory:
         with pytest.raises(ConfigError) as excinfo:
             ans_inv.create_inventory()
         assert "dictionary" in str(excinfo.value)
+
+    @pytest.mark.parametrize(
+        "layout",
+        [
+            # It is more tolerant with falsy values
+            common_inventory_layout(),
+            None,
+            {},
+            empty_layout(),
+            [],
+            False,
+        ],
+    )
+    def test_meta_extra(self, layout, db_meta_extra, metadata):
+
+        config = provisioning_config(layout)
+        ans_inv = AnsibleInventoryOutput(config, db_meta_extra, metadata)
+        inventory = ans_inv.create_inventory()
+
+        first_host = inventory["all"]["hosts"][
+            metadata["domains"][0]["hosts"][0]["name"]
+        ]
+
+        assert (
+            "meta_compose_url" in first_host
+        ), "Host must have 'meta_compose_url' field"
+        assert "meta_compose_id" in first_host, "Host must have 'meta_compose_id' field"
+
+    @pytest.mark.parametrize(
+        "layout",
+        [
+            # It is more tolerant with falsy values
+            common_inventory_layout(),
+            None,
+            {},
+            empty_layout(),
+            [],
+            False,
+        ],
+    )
+    def test_not_meta_extra(self, layout, db, metadata):
+        """
+        Some images (such as Windows images) don't have extra meta data fields like
+        meta_compose_id and meta_compose_url, so inventory shouldn't output them
+        if not passed.
+        """
+
+        config = provisioning_config(layout)
+        ans_inv = AnsibleInventoryOutput(config, db, metadata)
+        inventory = ans_inv.create_inventory()
+
+        first_host = inventory["all"]["hosts"][
+            metadata["domains"][0]["hosts"][0]["name"]
+        ]
+
+        assert (
+            "meta_compose_url" not in first_host
+        ), "Host must NOT have 'meta_compose_url' field"
+        assert (
+            "meta_compose_id" not in first_host
+        ), "Host must NOT have 'meta_compose_id' field"


### PR DESCRIPTION
In order to know what image is the latest tag pointing to in Openstack,
meta_compose_id and meta_compose_url fields from image meta information are
printed out in the log and added to ansible inventory output.

Implemented in a way that allows extension for other providers with extra custom fields,
or images that don't have those fields at all.q